### PR TITLE
Added auto_reconnect option (from mongodb-native) to options

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -16,7 +16,7 @@ var mongo = require('mongodb');
  * Default options
  */
 
-var defaultOptions = {host: '127.0.0.1', port: 27017, collection: 'sessions'};
+var defaultOptions = {host: '127.0.0.1', port: 27017, collection: 'sessions', auto_reconnect: false};
 
 /**
  * Initialize MongoStore with the given `options`.
@@ -48,7 +48,8 @@ var MongoStore = module.exports = function MongoStore(options, callback) {
   };
   
   this.db = new mongo.Db(options.db || defaultOptions.db, new mongo.Server(options.host || defaultOptions.host,
-                                                                           options.port || defaultOptions.port, {}));
+                                                                           options.port || defaultOptions.port, 
+                                                                           {auto_reconnect: options.auto_reconnect || defaultOptions.auto_reconnect}));
   this.db.open(function(err, db) {
     if (err) {
       throw new Error('Error connecting to db');


### PR DESCRIPTION
The auto_reconnect option is in the mongodb nodejs driver, and I wanted my mongo-based session store to use it, too.

This is where it is used in mongodb-native
https://github.com/christkv/node-mongodb-native/blob/master/lib/mongodb/connection.js#L9
https://github.com/christkv/node-mongodb-native/blob/master/lib/mongodb/connection.js#L187

(among other places).

thanks!
Cory
