### PR TITLE
Server option for more configurability and replica sets

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -75,14 +75,21 @@ var MongoStore = module.exports = function MongoStore(options, callback) {
   if(!options.db) {
     throw new Error('Required MongoStore option `db` missing');
   }
-  
-  this.db = new mongo.Db(options.db,
-                         new mongo.Server(options.host || defaultOptions.host,
+
+  var server;
+  if(options.server) {
+    server = options.server;
+  } else {
+    server = new mongo.Server(options.host || defaultOptions.host,
                                           options.port || defaultOptions.port, 
                                           {
                                             auto_reconnect: options.auto_reconnect ||
                                               defaultOptions.auto_reconnect
-                                          }));
+                                          });
+  }
+
+  this.db = new mongo.Db(options.db, server);
+                                          
   
   this.db_collection_name = options.collection || defaultOptions.collection;
 


### PR DESCRIPTION
Adding support for a server option which will override the url host in order to support replica sets. Plus side is that this allows existing code to remain the same and doesn't require supporting whatever server options are added to the mongodb driver. Downside is that you would have to require('mongodb') and create the server or replsetserver yourself (only if you need the configurability though).
