### PR TITLE
Can we allow future versions of node on this?

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,5 @@
     "mongodb": ">=0.8.0"
   },
   "main": "index",
-  "engines": { "node": "0.4.x" }
+  "engines": { "node": ">= 0.4.0" }
 }


### PR DESCRIPTION
Allow future versions, like 0.6.1 that's out now, to install it, per discussion in issue #16 ?
