### PR TITLE
Ensure port is of type 'number'

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -40,7 +40,7 @@ var MongoStore = module.exports = function MongoStore(options, callback) {
     var db_url = url.parse(options.url);
 
     if (db_url.port) {
-      options.port = db_url.port;
+      options.port = parseInt(db_url.port);
     }
     
     if (db_url.pathname != undefined) {


### PR DESCRIPTION
`node-mongodb-native` expects the port to be of type `number` (https://github.com/christkv/node-mongodb-native/blob/master/lib/mongodb/connection/connection_pool.js#L10), however, the URL parser returns the port as a string.
