### PR TITLE
Change node version of package.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,5 @@
     "mongodb": ">=0.8.0"
   },
   "main": "index",
-  "engines": { "node": "0.4.x" }
+  "engines": "node >= 0.4.x"
 }


### PR DESCRIPTION
Connect-mongo works fine with node v.0.6.2.
I've changed the node engine from package.js from '= v0.4.x' to >= v0.4.x'.
