### PR TITLE
Fix .npmignore to actually be useful

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,9 @@
-support
-test
-examples
+.npmignore
+
+History.md
+Makefile
+Readme.md
+
+examples/
+support/
+test/


### PR DESCRIPTION
npm has a bug where it fails to ignore directories if they don't have the
trailing slash. Also add Readme, History, Makefile and other misc files to
.npmignore.
