### PR TITLE
Add stringify option to allow saving sessions not as a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mongo",
-  "version": "0.1.6-josh",
+  "version": "0.1.6",
   "description": "MongoDB session store for Connect",
   "keywords": ["connect", "mongo", "mongodb", "session", "express"],
   "author": "Casey Banner <kcbanner@gmail.com>",


### PR DESCRIPTION
Patch for https://github.com/kcbanner/connect-mongo/issues/10
