### PR TITLE
Update in MongoDB Connection

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -66,7 +66,7 @@ var MongoStore = module.exports = function MongoStore(options, callback) {
 
   var self = this;
   this._get_collection = function(callback) {
-    if (self.collection) {
+    if (self.collection && Db.serverConfig._serverState == "connected") {
       callback && callback(self.collection);
     } else {
 		Connect(options.url, function(err2, data)


### PR DESCRIPTION
With this commit I change the connection to be more simple and always check if the driver still connected. With the older version, when the database restart or shutdown, the connection fail and cant back, because "connected" flag is always true.
