### PR TITLE
Update package.json dependencies version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "keywords": ["connect", "mongo", "mongodb", "session", "express"],
   "author": "Casey Banner <kcbanner@gmail.com>",
   "dependencies": {
-    "connect": ">=1.0.3",
-    "mongodb": ">=0.8.0"
+    "connect": "1.x",
+    "mongodb": "0.9.x"
   },
   "main": "index",
   "engines": "node >= 0.4.x"


### PR DESCRIPTION
Connect 2.0 is out, and the current package.json do not prevent against its use.

Moreover, mongodb native driver has been updated.
