### PR TITLE
Added support for fully instantiated node-MongoDB-native object use in lieu of a new connection 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ via npm:
 
 ## Options
 
-  - `db` Database name
+  - `db` Database name OR fully instantiated node-mongo-native object
   - `collection` Collection (optional, default: `sessions`) 
   - `host` MongoDB server hostname (optional, default: `127.0.0.1`)
   - `port` MongoDB server port (optional, default: `27017`)

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -77,9 +77,10 @@ module.exports = function(connect) {
   
     if(!options.db) {
       throw new Error('Required MongoStore option `db` missing');
-    }
-    
-    this.db = new mongo.Db(options.db,
+    }else if(typeof options.db == "object"){
+      this.db = options.db;	// Assume it's an instantiated DB Object
+    }else{
+      this.db = new mongo.Db(options.db,
                            new mongo.Server(
                              options.host || defaultOptions.host,
                              options.port || defaultOptions.port, 
@@ -87,7 +88,7 @@ module.exports = function(connect) {
                                auto_reconnect: options.auto_reconnect ||
                                  defaultOptions.auto_reconnect
                              }));
-    
+    }
     this.db_collection_name = options.collection || defaultOptions.collection;
 
     if (options.hasOwnProperty('stringify') ?


### PR DESCRIPTION
This enhancement allows existing database connections to be reused for mongo sessions storage rather than requiring a separate connection be setup (which in any node app already using MongoDB, forces the sessions collection into a separate database, as node-mongo-native doesn't permit multiple opens on the same database by the same application. This enhancement adds flexibility of the mongo session handler overall, and extends it's suitability to a new set of use cases.
