### PR TITLE
Add support for Write Concern

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -21,6 +21,7 @@ var defaultOptions = {host: '127.0.0.1',
                       stringify: true,
                       collection: 'sessions',
                       auto_reconnect: false,
+                      w: 1,
                       clear_interval: -1};
 
 module.exports = function(connect) {
@@ -98,7 +99,9 @@ module.exports = function(connect) {
                                               {
                                                 auto_reconnect: options.auto_reconnect ||
                                                   defaultOptions.auto_reconnect
-                                              }));
+                                              }), {
+                                                w: options.w || defaultOptions.w
+                                              });
     }
     
     this.db_collection_name = options.collection || defaultOptions.collection;


### PR DESCRIPTION
Add support for setting the write concern option supported in the 1.2 nodejs driver, and default to w: 1 (as prescribed by the MongoDB documentation).
