### PR TITLE
Update connect-mongo.js

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -134,6 +134,9 @@ module.exports = function(connect) {
             // mongo to remove anything expired without any additional delay.
             self.collection.ensureIndex({expires: 1}, {expireAfterSeconds: 0}, function(err, result) {
               if (err) {
+                console.log(err);  // if user not created an auth for database ( especially work on localhost )
+                                   // mongodb returns an TTL error because of it couldn't write to database
+                                   // via ensureIndex(), console.log(err) help to us to see mongodb error. ;)
                 throw new Error('Error setting TTL index on collection : ' + self.db_collection_name);
               }
               


### PR DESCRIPTION
if user not created an auth for database ( especially work on localhost ) mongodb returns an TTL error because of it couldn't write to database via ensureIndex(), console.log(err) help to us to see mongodb error. ;)
