### PR TITLE
Configurable Default Expiration Time

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -238,15 +238,16 @@ module.exports = function(connect) {
     try {
       var s = {_id: sid, session: this._serialize_session(session)};
 
-      if (session && session.cookie) {
-        if (session.cookie.expires) {
-          s.expires = new Date(session.cookie.expires);
-        }
+      if (session && session.cookie && session.cookie.expires) {
+        s.expires = new Date(session.cookie.expires);
       } else {
         // If there's no expiration date specified, it is
-        // browser-session cookie, as per the connect docs.
-        // So we set the expiration to two-weeks from now,
-        // as is common practice in the industry (e.g Django).
+        // browser-session cookie or there is no cookie at all,
+        // as per the connect docs.
+        //
+        // So we set the expiration to two-weeks from now
+        // - as is common practice in the industry (e.g Django) -
+        // or the default specified in the options.
         var today = new Date();
         s.expires = new Date(today.getTime() + this.defaultExpirationTime);
       }


### PR DESCRIPTION
This patch makes the default expiration time configurable.

Also, always set an expiration time even if no cookie is present. Setting an expiration for sessions without cookies is useful if the sessions are linked to requests via custom headers.
