### PR TITLE
Propagates the error message from Mongo to the Error object

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -125,7 +125,7 @@ module.exports = function(connect) {
       } else {
         self.db.collection(self.db_collection_name, function(err, collection) {
           if (err) {
-            throw new Error('Error getting collection: ' + self.db_collection_name);
+            throw new Error('Error getting collection: ' + self.db_collection_name  + ' <' + err + '>');
           } else {
             self.collection = collection;
 
@@ -134,7 +134,7 @@ module.exports = function(connect) {
             // mongo to remove anything expired without any additional delay.
             self.collection.ensureIndex({expires: 1}, {expireAfterSeconds: 0}, function(err, result) {
               if (err) {
-                throw new Error('Error setting TTL index on collection : ' + self.db_collection_name);
+                throw new Error('Error setting TTL index on collection : ' + self.db_collection_name + ' <' + err + '>');
               }
               
               callback && callback(self.collection);
@@ -150,7 +150,7 @@ module.exports = function(connect) {
     else {
       this.db.open(function(err, db) {
         if (err) {
-          throw new Error('Error connecting to database');
+          throw new Error('Error connecting to database <' + err + '>');
         }
 
         if (options.username && options.password) {


### PR DESCRIPTION
Found it hard to work out what Mongo was actually complaining about. An example I got form this is below.

Error: Error setting TTL index on collection : sessions <MongoError: not master and slaveOk=false>
