### PR TITLE
Update connect-mongo.js

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -171,19 +171,23 @@ module.exports = function(connect) {
     };
     
     this._open_database = function(cb){
-      self.db.open(function(err, db) {
-        if (err) {
-          throw new Error('Error connecting to database');
-        }
+      if (self.db.openCalled) {
+        self._get_collection(cb);                            
+      } else {                         
+        self.db.open(function(err, db) {
+          if (err) {
+            throw new Error('Error connecting to database');
+          }
 
-        if (options.username && options.password) {
-          db.authenticate(options.username, options.password, function () {
+          if (options.username && options.password) {
+            db.authenticate(options.username, options.password, function () {
+              self._get_collection(cb);
+            });
+          } else {
             self._get_collection(cb);
-          });
-        } else {
-          self._get_collection(cb);
-        }
-      });
+          }
+        });
+      }
     };
 
     this.defaultExpirationTime = options.defaultExpirationTime || defaultOptions.defaultExpirationTime;


### PR DESCRIPTION
If db connection already open go directly to collection. This logic was available v0.3.3 but seems to have been dropped along the way.

Thanks.
