### PR TITLE
Propagate the original connection error, including reason and stack.

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -173,7 +173,9 @@ module.exports = function(connect) {
     this._open_database = function(cb){
       self.db.open(function(err, db) {
         if (err) {
-          throw new Error('Error connecting to database');
+          if (!(err instanceof Error)) { err = new Error(String(err)); }
+          err.message = 'Error connecting to database: ' + err.message;
+          throw err;
         }
 
         if (options.username && options.password) {


### PR DESCRIPTION
because knowing _why_ a connection failed, helps fixing it.
