### PR TITLE
don't call open again if it's already opened

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -27,7 +27,7 @@ var defaultOptions = {host: '127.0.0.1',
                      };
 
 module.exports = function(connect) {
-  var Store = connect.session.Store;
+  var Store = connect.Store || connect.session.Store;
 
   /**
    * Initialize MongoStore with the given `options`.


### PR DESCRIPTION
This gets rid of the exception when I pass in a mongoose db that's already opened.
