### PR TITLE
Adding authdb support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,7 @@ via npm:
   - `port` MongoDB server port (optional, default: `27017`)
   - `username` Username (optional)
   - `password` Password (optional)
+  - `authdb` The database that holds the user's credentials. Defaults to `db` (optional)
   - `auto_reconnect` This is passed directly to the MongoDB `Server` constructor as the auto_reconnect
                      option (optional, default: false).
   - `ssl` Use SSL to connect to MongoDB (optional, default: false).

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -82,6 +82,7 @@ module.exports = function(connect) {
       if (options.mongoose_connection.user && options.mongoose_connection.pass) {
         options.username = options.mongoose_connection.user;
         options.password = options.mongoose_connection.pass;
+        options.authdb = options.mongoose_connection.options.auth.authdb || options.authdb || '';
       }
 
       this.db = new mongo.Db(options.mongoose_connection.db.databaseName,
@@ -111,7 +112,10 @@ module.exports = function(connect) {
                                { w: options.w || defaultOptions.w });
       }
     }
-    
+
+    // Use the database being connected to if a specific authentication database is not set.
+    options.authdb = options.authdb || options.db;
+
     this.db_collection_name = options.collection || defaultOptions.collection;
 
     if (options.hasOwnProperty('stringify') ? options.stringify : defaultOptions.stringify) {
@@ -179,7 +183,7 @@ module.exports = function(connect) {
         }
 
         if (options.username && options.password) {
-          db.authenticate(options.username, options.password, function () {
+          db.authenticate(options.username, options.password, {authdb: options.authdb}, function () {
             self._get_collection(cb);
           });
         } else {


### PR DESCRIPTION
Adding authdb option to constructor and pulling authdb from mongoose_connection options if it exists.
