### PR TITLE
Add configuration option to prevent persisting selected properties

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,7 @@ via npm:
                 setting them, and deserialize them with `JSON.parse` when getting them.
                 (optional, default: true). This is useful if you are using types that 
                 MongoDB doesn't support.
+  - `transientProperties` Array of names of transient session properties that will not be persisted.
 
 The second parameter to the `MongoStore` constructor is a callback which will be called once the database connection is established.
 This is mainly used for the tests, however you can use this callback if you want to wait until the store has connected before

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -24,7 +24,7 @@ var defaultOptions = {host: '127.0.0.1',
                       ssl: false,
                       w: 1,
                       defaultExpirationTime:  1000 * 60 * 60 * 24 * 14,
-                      ignoredProperties: []
+                      transientProperties: []
                      };
 
 module.exports = function(connect) {
@@ -115,14 +115,14 @@ module.exports = function(connect) {
     
     this.db_collection_name = options.collection || defaultOptions.collection;
 
-    if (options.ignoredProperties) {
-      if (!(options.ignoredProperties instanceof Array)) {
+    if (options.transientProperties) {
+      if (!(options.transientProperties instanceof Array)) {
         throw new Error('Required MongoStore option `db` missing');
       } else {
-        this.ignoredProperties = options.ignoredProperties;
+        this.transientProperties = options.transientProperties;
       }
     } else {
-      this.ignoredProperties = defaultOptions.ignoredProperties;
+      this.transientProperties = defaultOptions.transientProperties;
     }
 
     if (options.hasOwnProperty('stringify') ? options.stringify : defaultOptions.stringify) {
@@ -135,7 +135,7 @@ module.exports = function(connect) {
       // Copy each property of the session to a new object
       var obj = {};
       for (var prop in session) {
-        if (!this.ignoredProperties || this.ignoredProperties.indexOf(prop) === -1) {
+        if (!this.transientProperties || this.transientProperties.indexOf(prop) === -1) {
           if (prop === 'cookie') {
             
             // Convert the cookie instance to an object, if possible

--- a/test/connect-mongo.test.js
+++ b/test/connect-mongo.test.js
@@ -736,13 +736,13 @@ exports.test_set_witout_default_expiration = function(done) {
   });
 };
 
-exports.test_with_default_ignored_properties_no_stringify = function(done) {
+exports.test_with_default_transient_properties_no_stringify = function(done) {
   var additionalProperties = ['test1','test2','test3'];
-  var optionsWithoutIgnoredProperties = JSON.parse(JSON.stringify(options));
-  optionsWithoutIgnoredProperties['stringify'] = false;
+  var optionsWithoutTransientProperties = JSON.parse(JSON.stringify(options));
+  optionsWithoutTransientProperties['stringify'] = false;
 
-  open_db(optionsWithoutIgnoredProperties, function(store, db, collection) {
-    var sid = 'test_default_ignored_properties_no_stringify-sid';
+  open_db(optionsWithoutTransientProperties, function(store, db, collection) {
+    var sid = 'test_default_transient_properties_no_stringify-sid';
     var data = make_data_no_cookie();
     additionalProperties.forEach(function(element) {
       data[element] = element;
@@ -763,13 +763,13 @@ exports.test_with_default_ignored_properties_no_stringify = function(done) {
   });
 };
 
-exports.test_with_default_ignored_properties_stringify = function(done) {
+exports.test_with_default_transient_properties_stringify = function(done) {
   var additionalProperties = ['test1','test2','test3'];
-  var optionsWithoutIgnoredProperties = JSON.parse(JSON.stringify(options));
-  optionsWithoutIgnoredProperties['stringify'] = true;
+  var optionsWithoutTransientProperties = JSON.parse(JSON.stringify(options));
+  optionsWithoutTransientProperties['stringify'] = true;
 
-  open_db(optionsWithoutIgnoredProperties, function(store, db, collection) {
-    var sid = 'test_default_ignored_properties_stringify-sid';
+  open_db(optionsWithoutTransientProperties, function(store, db, collection) {
+    var sid = 'test_default_transient_properties_stringify-sid';
     var data = make_data_no_cookie();
     additionalProperties.forEach(function(element) {
       data[element] = element;
@@ -790,16 +790,16 @@ exports.test_with_default_ignored_properties_stringify = function(done) {
   });
 };
 
-exports.test_with_ignored_properties_no_stringify = function(done) {
-  var ignoredProperties = ['test1','test2','test3'];
-  var optionsWithIgnoredProperties = JSON.parse(JSON.stringify(options));
-  optionsWithIgnoredProperties['ignoredProperties'] = ignoredProperties;
-  optionsWithIgnoredProperties['stringify'] = false;
+exports.test_with_transient_properties_no_stringify = function(done) {
+  var transientProperties = ['test1','test2','test3'];
+  var optionsWithTransientProperties = JSON.parse(JSON.stringify(options));
+  optionsWithTransientProperties['transientProperties'] = transientProperties;
+  optionsWithTransientProperties['stringify'] = false;
 
-  open_db(optionsWithIgnoredProperties, function(store, db, collection) {
-    var sid = 'test_set_ignored_properties_no_stringify-sid';
+  open_db(optionsWithTransientProperties, function(store, db, collection) {
+    var sid = 'test_set_transient_properties_no_stringify-sid';
     var data = make_data_no_cookie();
-    ignoredProperties.forEach(function(element) {
+    transientProperties.forEach(function(element) {
       data[element] = element;
     });
 
@@ -808,7 +808,7 @@ exports.test_with_ignored_properties_no_stringify = function(done) {
 
       collection.findOne({_id: sid}, function(err, session) {
         var expectedResult = JSON.parse(JSON.stringify(data));
-        ignoredProperties.forEach(function(element) {
+        transientProperties.forEach(function(element) {
           delete expectedResult[element];
         });
 
@@ -823,16 +823,16 @@ exports.test_with_ignored_properties_no_stringify = function(done) {
   });
 };
 
-exports.test_with_ignored_properties_stringify = function(done) {
-  var ignoredProperties = ['test1','test2','test3'];
-  var optionsWithIgnoredProperties = JSON.parse(JSON.stringify(options));
-  optionsWithIgnoredProperties['ignoredProperties'] = ignoredProperties;
-  optionsWithIgnoredProperties['stringify'] = true;
+exports.test_with_transient_properties_stringify = function(done) {
+  var transientProperties = ['test1','test2','test3'];
+  var optionsWithTransientProperties = JSON.parse(JSON.stringify(options));
+  optionsWithTransientProperties['transientProperties'] = transientProperties;
+  optionsWithTransientProperties['stringify'] = true;
 
-  open_db(optionsWithIgnoredProperties, function(store, db, collection) {
-    var sid = 'test_set_ignored_properties_no_stringify-sid';
+  open_db(optionsWithTransientProperties, function(store, db, collection) {
+    var sid = 'test_set_transient_properties_no_stringify-sid';
     var data = make_data_no_cookie();
-    ignoredProperties.forEach(function(element) {
+    transientProperties.forEach(function(element) {
       data[element] = element;
     });
 
@@ -841,7 +841,7 @@ exports.test_with_ignored_properties_stringify = function(done) {
 
       collection.findOne({_id: sid}, function(err, session) {
         var expectedResult = JSON.parse(JSON.stringify(data));
-        ignoredProperties.forEach(function(element) {
+        transientProperties.forEach(function(element) {
           delete expectedResult[element];
         });
 


### PR DESCRIPTION
This is useful for cases where the session stores some transient data required only for the current request. The transient data needs to be pre-configured via ignoredProperties option.
