### PR TITLE
Made compatible to Express 4.x

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -27,7 +27,7 @@ var defaultOptions = {host: '127.0.0.1',
                      };
 
 module.exports = function(connect) {
-  var Store = connect.session.Store;
+  var Store = connect.Store || connect.session.Store;
 
   /**
    * Initialize MongoStore with the given `options`.


### PR DESCRIPTION
In Express 4.x, express.session does not exist any more, but is put into npm module express-session.
So now if you want to use it use mongoStore(expressSession)
