### PR TITLE
Added support for mongoose mongdb cluster

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -84,14 +84,13 @@ module.exports = function(connect) {
         options.password = options.mongoose_connection.pass;
       }
 
-      var master = 0;
-      options.mongoose_connection.db.serverConfig.servers.forEach(function(server, index){
-        if(server.db != undefined){
-          master = index;
-        }
-      })
-
       if(options.mongoose_connection.db.serverConfig.servers){ // using elastic mongodb
+        var master = 0;
+        options.mongoose_connection.db.serverConfig.servers.forEach(function(server, index){
+          if(server.db != undefined){
+            master = index;
+          }
+        })
         options.host = options.mongoose_connection.db.serverConfig.servers[master].host;
         options.port = options.mongoose_connection.db.serverConfig.servers[master].port;
         options.options = options.mongoose_connection.db.serverConfig.servers[master].options;


### PR DESCRIPTION
We use MongoHQ's elastic deployment and when handing mongo-store a mongoose connection with more than one connected server, it threw some errors. This commit/pull request contains a fix. It will check to see if mongoose is connected to multiple servers and just grab the first one.

P.S. Sorry about the removal of the whitespace at the end of each line, Sublime Text automatically does that for me.
