### PR TITLE
Add support for replicaset when using mongoose

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -84,13 +84,22 @@ module.exports = function(connect) {
         options.password = options.mongoose_connection.pass;
       }
 
-      this.db = new mongo.Db(options.mongoose_connection.db.databaseName,
-                             new mongo.Server(options.mongoose_connection.db.serverConfig.host,
-                                              options.mongoose_connection.db.serverConfig.port,
-                                              options.mongoose_connection.db.serverConfig.options
-                                             ),
-                             { w: options.w || defaultOptions.w });
-
+      if (options.mongoose_connection.db.serverConfig.servers) {
+        var servers = options.mongoose_connection.db.serverConfig.servers.map(function(s) {
+          return new mongo.Server(s.host, s.port, s.options);
+        });
+        this.db = new mongo.Db(options.mongoose_connection.db.databaseName,
+                               new mongo.ReplSetServers(servers),
+                               { w: options.w || defaultOptions.w });
+      }
+      else {
+        this.db = new mongo.Db(options.mongoose_connection.db.databaseName,
+                               new mongo.Server(options.mongoose_connection.db.serverConfig.host,
+                                                options.mongoose_connection.db.serverConfig.port,
+                                                options.mongoose_connection.db.serverConfig.options
+                                               ),
+                               { w: options.w || defaultOptions.w });
+      }
     } else {
       if(!options.db) {
         throw new Error('Required MongoStore option `db` missing');


### PR DESCRIPTION
This uses `mongo.ReplSetServers` to group all servers found in the mongoose connection. 

See https://github.com/christkv/node-mongodb-native/blob/master/examples/replSetServersQueries.js
