### PR TITLE
enabled auth.authSource support for mongoose users

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -84,6 +84,10 @@ module.exports = function(connect) {
         options.password = options.mongoose_connection.pass;
       }
 
+      if(options.mongoose_connection.options.auth.authSource){
+        options.authSource = options.mongoose_connection.options.auth.authSource;
+      }
+
       this.db = new mongo.Db(options.mongoose_connection.db.databaseName,
                              new mongo.Server(options.mongoose_connection.db.serverConfig.host,
                                               options.mongoose_connection.db.serverConfig.port,
@@ -179,12 +183,17 @@ module.exports = function(connect) {
         }
 
         if (options.username && options.password) {
-          db.authenticate(options.username, options.password, function () {
+          var extra_options = {};
+          if(options.authSource){
+            extra_options.authSource = options.authSource;
+          }
+          db.authenticate(options.username, options.password, extra_options, function () {
             self._get_collection(cb);
           });
         } else {
           self._get_collection(cb);
         }
+        
       });
     };
 


### PR DESCRIPTION
This will allow users who are using a separate database to auth their users to use connect-mongo, it's a relatively small change but I fear my code style may not match yours!
