### PR TITLE
Added support for Replica Set

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -83,14 +83,24 @@ module.exports = function(connect) {
         options.username = options.mongoose_connection.user;
         options.password = options.mongoose_connection.pass;
       }
-
+      if (Array.isArray(options.mongoose_connection.hosts)) {
+          var servers = options.mongoose_connection.db.serverConfig.servers.map(function (server){
+            return new mongo.Server(server.host, server.port, {auto_reconnect: true});
+          });
+        var rlset = new mongo.ReplSetServers(servers);
+        this.db = new mongo.Db(
+            options.mongoose_connection.db.databaseName,
+            rlset,
+              { w: options.w || defaultOptions.w }
+          );
+      } else {                      
       this.db = new mongo.Db(options.mongoose_connection.db.databaseName,
                              new mongo.Server(options.mongoose_connection.db.serverConfig.host,
                                               options.mongoose_connection.db.serverConfig.port,
                                               options.mongoose_connection.db.serverConfig.options
                                              ),
                              { w: options.w || defaultOptions.w });
-
+      }
     } else {
       if(!options.db) {
         throw new Error('Required MongoStore option `db` missing');


### PR DESCRIPTION
When reusing mongoose.connection

BTW: 
when:
 `Error: Error setting TTL index on collection : sessions`
then:
http://stackoverflow.com/questions/22698661/mongodb-error-setting-ttl-index-on-collection-sessions
