### PR TITLE
Enable connecting with mongodb URI

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -11,7 +11,6 @@
 var mongo = require('mongodb');
 var url = require('url');
 
-
 /**
  * Default options
  */
@@ -42,7 +41,17 @@ module.exports = function(connect) {
     options = options || {};
     Store.call(this, options);
 
-    if(options.url) {
+    if (options.uri) {
+      mongo.MongoClient.connect(options.uri, function(err, db) {
+        if (err) {
+          return callback(err);
+        }
+        self.db = db;
+        self._get_collection(function(collection) {
+          callback && callback(collection);
+        });
+      });
+    } else if (options.url) {
       var db_url = url.parse(options.url);
 
       if (db_url.port) {
@@ -91,7 +100,7 @@ module.exports = function(connect) {
                                              ),
                              { w: options.w || defaultOptions.w });
 
-    } else {
+    } else if(!options.uri) {
       if(!options.db) {
         throw new Error('Required MongoStore option `db` missing');
       }
@@ -189,9 +198,11 @@ module.exports = function(connect) {
     };
 
     this.defaultExpirationTime = options.defaultExpirationTime || defaultOptions.defaultExpirationTime;
-    
-    callback && this._open_database(callback);
-    
+
+    if (!options.uri) {
+      callback && this._open_database(callback);
+    }
+
   };
 
   /**

--- a/test/connect-mongo.test.js
+++ b/test/connect-mongo.test.js
@@ -309,6 +309,19 @@ exports.test_options_url = function(done) {
   });
 };
 
+exports.test_options_uri = function(done) {
+  var store = new MongoStore({
+    uri: 'mongodb://127.0.0.1:27017/connect-mongo-test'
+  }, function() {
+    assert.strictEqual(store.db.databaseName, 'connect-mongo-test');
+    assert.strictEqual(store.db.serverConfig.host, '127.0.0.1');
+    assert.equal(store.db.serverConfig.port, 27017);
+    assert.equal(store.collection.collectionName, 'sessions');
+    cleanup_store(store);
+    done();
+  });
+};
+
 exports.test_options_url_auth = function(done) {
   var store = new MongoStore({
     url: 'mongodb://test:test@127.0.0.1:27017/connect-mongo-test/sessions-test'


### PR DESCRIPTION
Heya,

Great module, but would be much more useful if you could use [MongoDB connection strings](http://docs.mongodb.org/manual/reference/connection-string/). That way you can actually use connect-mongo to specify a seed list for connecting to replica sets / sharded clusters. Right now it really only works if you're connecting to a single server, which is quite limiting.
