### PR TITLE
fix(deps): use Connect 2.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
       "lib":"./lib"
   },
   "devDependencies": {
+    "connect": "2.27.6",
     "mocha": "1.x",
-    "connect": ">= 1.x",
     "mongoose": ">= 2.6.x"
   },
   "scripts" : { "test": "make test" },


### PR DESCRIPTION
Connect 3.x removed session cookies from core, causing tests to fail for anyone with Connect 3.x installed. This change forces it back to the last good state.
