### PR TITLE
feat: custom serialize and unserialize functions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,13 @@ via npm:
                 setting them, and deserialize them with `JSON.parse` when getting them.
                 (optional, default: true). This is useful if you are using types that 
                 MongoDB doesn't support.
+  - `serialize` Custom hook for serializing sessions to MongoDB. This is helpful if you need
+                to modify the session before writing it out. It takes precedence over the
+                `stringify` option.
+  - `unserialize` Custom hook for unserializing sessions from MongoDB. This can be used in
+                scenarios where you need to support different types of serializations
+                (e.g., objects and JSON strings) or need to modify the session before using
+                it in your app. It takes precedence over the `stringify` option.
 
 The second parameter to the `MongoStore` constructor is a callback which will be called once the database connection is established.
 This is mainly used for the tests, however you can use this callback if you want to wait until the store has connected before

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -26,6 +26,26 @@ var defaultOptions = {host: '127.0.0.1',
                       defaultExpirationTime:  1000 * 60 * 60 * 24 * 14
                      };
 
+function defaultSerializer (session) {
+  // Copy each property of the session to a new object
+  var obj = {};
+  for (var prop in session) {
+    if (prop === 'cookie') {
+
+    // Convert the cookie instance to an object, if possible
+    // This gets rid of the duplicate object under session.cookie.data property
+
+      obj.cookie = session.cookie.toJSON ? session.cookie.toJSON() : session.cookie;
+    } else {
+      obj[prop] = session[prop];
+    }
+  }
+
+  return obj;
+}
+
+function identity (x) { return x; }
+
 module.exports = function(connect) {
   var Store = connect.Store || connect.session.Store;
 
@@ -115,30 +135,11 @@ module.exports = function(connect) {
     this.db_collection_name = options.collection || defaultOptions.collection;
 
     if (options.hasOwnProperty('stringify') ? options.stringify : defaultOptions.stringify) {
-      this._serialize_session = JSON.stringify;
-      this._unserialize_session = JSON.parse;
+      this._serialize_session = options.serialize || JSON.stringify;
+      this._unserialize_session = options.unserialize || JSON.parse;
     } else {
-      
-      // Copy each property of the session to a new object
-      
-      this._serialize_session = function(session) {
-        var obj = {};
-        for (var prop in session) {
-          if (prop === 'cookie') {
-            
-            // Convert the cookie instance to an object, if possible
-            // This gets rid of the duplicate object under session.cookie.data property
-            
-            obj.cookie = session.cookie.toJSON ? session.cookie.toJSON() : session.cookie;
-          } else {
-            obj[prop] = session[prop];
-          }
-        }
-
-        return obj;
-      };
-
-      this._unserialize_session = function(x) { return x; };
+      this._serialize_session = options.serialize || defaultSerializer;
+      this._unserialize_session = options.unserialize || identity;
     }
     
     var self = this;

--- a/test/connect-mongo.test.js
+++ b/test/connect-mongo.test.js
@@ -735,3 +735,54 @@ exports.test_set_witout_default_expiration = function(done) {
     });
   });
 };
+
+exports.test_set_custom_serializer = function (done) {
+  open_db({
+    db: options.db,
+    serialize: function (obj) {
+      obj.ice = 'test-1';
+      return JSON.stringify(obj)
+    }
+  }, function (store, db, collection) {
+    var sid = 'test_set_custom_serializer-sid';
+    var data = make_data(),
+      dataWithIce = JSON.parse(JSON.stringify(data));
+
+    dataWithIce.ice = 'test-1';
+    store.set(sid, data, function (err, session) {
+      assert.strictEqual(err, null);
+
+      collection.findOne({_id: sid}, function (err, session) {
+        assert.deepEqual(session.session, JSON.stringify(dataWithIce));
+        assert.strictEqual(session._id, sid);
+
+        cleanup(store, db, collection, done);
+      });
+    });
+  });
+};
+
+exports.test_get_custom_unserializer = function (done) {
+  open_db({
+    db: options.db,
+    unserialize: function (str) {
+      var obj = JSON.parse(str);
+      obj.ice = 'test-2';
+      return obj;
+    }
+  }, function (store, db, collection) {
+    var sid = 'test_get_custom_unserializer-sid';
+    var data = make_data(),
+      dataWithIce = JSON.parse(JSON.stringify(data));
+
+    dataWithIce.ice = 'test-2';
+    store.set(sid, data, function (err, session) {
+      assert.strictEqual(err, null);
+      store.get(sid, function (err, session) {
+        assert.strictEqual(err, null);
+        assert.deepEqual(session, dataWithIce);
+        cleanup(store, db, collection, done);
+      });
+    });
+  });
+};


### PR DESCRIPTION
This is something my team for my day job needs to perform a certain upgrade. I'm going to publish it to NPM under a different name so we can get this done, but I'm also submitting it here in case the project is still maintained and someone might find it useful.

It adds custom hooks for serializing and deserializing functions. If specified, they will be used instead of `JSON.parse`/`JSON.stringify` or the default behavior already in the library. This will allow us to perform an upgrade where we will need to support deserializing from strings and from objects for a window of time.
