### PR TITLE
feat: unserialize strings or objects

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -26,6 +26,17 @@ var defaultOptions = {host: '127.0.0.1',
                       defaultExpirationTime:  1000 * 60 * 60 * 24 * 14
                      };
 
+function unserialize (value) {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch (e) {
+      return value;
+    }
+  }
+  return value;
+}
+
 module.exports = function(connect) {
   var Store = connect.Store || connect.session.Store;
 
@@ -116,7 +127,7 @@ module.exports = function(connect) {
 
     if (options.hasOwnProperty('stringify') ? options.stringify : defaultOptions.stringify) {
       this._serialize_session = JSON.stringify;
-      this._unserialize_session = JSON.parse;
+      this._unserialize_session = unserialize;
     } else {
       
       // Copy each property of the session to a new object
@@ -138,7 +149,7 @@ module.exports = function(connect) {
         return obj;
       };
 
-      this._unserialize_session = function(x) { return x; };
+      this._unserialize_session = unserialize;
     }
     
     var self = this;


### PR DESCRIPTION
This change makes it so the unserializing function is always the same
and supports objects or JSON encoded strings. Possibly breaking, if your
code stores JSON in a string and expects it to come back as a
JSON-encoded string.
