### PR TITLE
Missing Sessions from DB should still make callback

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -248,6 +248,8 @@ module.exports = function(connect) {
           } else {
             self.destroy(sid, callback);
           }
+        } else {
+          callback();
         }
       });
     });


### PR DESCRIPTION
A callback to the session module was not sent if the session was not found in the database, causing the app to never `next()` and move on.
