### PR TITLE
Update to #228

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,7 @@ module.exports = function connectMongo(connect) {
                 .then(collection => collection.updateAsync({ _id: this.computeStorageId(sid) }, s, { upsert: true }))
                 .then(responseArray => {
                     const rawResponse = responseArray.length === 2 ? responseArray[1] : responseArray[0].result;
-                    if (rawResponse.upserted) {
+                    if (rawResponse && rawResponse.upserted) {
                         this.emit('create', sid);
                     } else {
                         this.emit('update', sid);


### PR DESCRIPTION
Still receiving this error after 1.3.2.

TypeError: Cannot read property 'upserted' of undefined
     at /root/app/node_modules/connect-mongo/src/index.js:251:36
     at tryCatcher (/root/app/node_modules/connect-mongo/node_modules/bluebird/js/release/util.js:16:23)
     at Promise._settlePromiseFromHandler (/root/app/node_modules/connect-mongo/node_modules/bluebird/js/release/promise.js:504:31)
     at Promise._settlePromise (/root/app/node_modules/connect-mongo/node_modules/bluebird/js/release/promise.js:561:18)
     at Promise._settlePromise0 (/root/app/node_modules/connect-mongo/node_modules/bluebird/js/release/promise.js:606:10)
     at Promise._settlePromises (/root/app/node_modules/connect-mongo/node_modules/bluebird/js/release/promise.js:685:18)
     at Promise._fulfill (/root/app/node_modules/connect-mongo/node_modules/bluebird/js/release/promise.js:630:18)
     at /root/app/node_modules/connect-mongo/node_modules/bluebird/js/release/nodeback.js:45:21
     at /root/app/node_modules/mongojs/lib/collection.js:105:7
     at handleCallback (/root/app/node_modules/mongodb/lib/utils.js:96:12)
     at /root/app/node_modules/mongodb/lib/collection.js:1034:5
     at /root/app/node_modules/mongodb/node_modules/mongodb-core/lib/connection/pool.js:428:18
     at nextTickCallbackWith0Args (node.js:420:9)
     at process._tickDomainCallback (node.js:390:13)
