### PR TITLE
avoiding calling touch in get

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -205,7 +205,7 @@ module.exports = function connectMongo(connect) {
                         if (this.options.touchAfter > 0 && session.lastModified) {
                             s.lastModified = session.lastModified;
                         }
-                        this.emit('touch', sid);
+                        this.emit('get', sid);
                         return s;
                     }
                 })


### PR DESCRIPTION
`sessionStore.on('touch', ...)` gets called on every requests currently (with `touchAfter` option enabled), this change makes it work as expected (max one call every touchAfter periods)

only https://github.com/jdesboeufs/connect-mongo/blob/master/src/index.js#L294 should emit touch