### PR TITLE
swap ensureIndex with createIndex fixes #268

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ module.exports = function connectMongo(connect) {
             let removeQuery = { expires: { $lt: new Date() } };
             switch (this.autoRemove) {
             case 'native':
-                return this.collection.ensureIndexAsync({ expires: 1 }, { expireAfterSeconds: 0 });
+                return this.collection.createIndexAsync({ expires: 1 }, { expireAfterSeconds: 0 });
             case 'interval':
                 this.timer = setInterval(() => this.collection.remove(removeQuery, { w: 0 }), this.autoRemoveInterval * 1000 * 60);
                 this.timer.unref();
@@ -151,7 +151,7 @@ module.exports = function connectMongo(connect) {
             this.collection = collection;
 
             // Promisify used collection methods
-            ['count', 'findOne', 'remove', 'drop', 'ensureIndex'].forEach(method => {
+            ['count', 'findOne', 'remove', 'drop', 'createIndex'].forEach(method => {
                 collection[method + 'Async'] = Promise.promisify(collection[method], { context: collection });
             });
             collection.updateAsync = Promise.promisify(collection.update, { context: collection, multiArgs: true });


### PR DESCRIPTION
Have a look at mongodb [docs](https://docs.mongodb.com/manual/reference/method/db.collection.ensureIndex/)

## Definition

db.collection.ensureIndex(keys, options)  

Deprecated since version 3.0.0: db.collection.ensureIndex() is now an alias for db.collection.createIndex().

Creates an index on the specified field if the index does not already exist.

## Additional Information

Use db.collection.createIndex() rather than db.collection.ensureIndex() to create new indexes.