### PR TITLE
Replace ensureIndex with createIndex, fixing #268.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ module.exports = function connectMongo(connect) {
             let removeQuery = { expires: { $lt: new Date() } };
             switch (this.autoRemove) {
             case 'native':
-                return this.collection.ensureIndexAsync({ expires: 1 }, { expireAfterSeconds: 0 });
+                return this.collection.createIndexAsync({ expires: 1 }, { expireAfterSeconds: 0 });
             case 'interval':
                 this.timer = setInterval(() => this.collection.remove(removeQuery, { w: 0 }), this.autoRemoveInterval * 1000 * 60);
                 this.timer.unref();
@@ -151,7 +151,7 @@ module.exports = function connectMongo(connect) {
             this.collection = collection;
 
             // Promisify used collection methods
-            ['count', 'findOne', 'remove', 'drop', 'ensureIndex'].forEach(method => {
+            ['count', 'findOne', 'remove', 'drop', 'createIndex'].forEach(method => {
                 collection[method + 'Async'] = Promise.promisify(collection[method], { context: collection });
             });
             collection.updateAsync = Promise.promisify(collection.update, { context: collection, multiArgs: true });


### PR DESCRIPTION
This fixes the warning issued by mongoose: `DeprecationWarning: `ensureIndex()` is deprecated in Mongoose >= 4.12.0, use `createIndex()` instead`