### PR TITLE
Fixes a crash during session destruction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -294,7 +294,7 @@ module.exports = function (connect) {
 
     destroy(sid, callback) {
       return withCallback(this.collectionReady()
-                .then(collection => collection.remove({_id: this.computeStorageId(sid)}))
+                .then(collection => collection.remove({_id: this.computeStorageId(sid)}, {skipSessions: true}))
                 .then(() => this.emit('destroy', sid))
               , callback)
     }


### PR DESCRIPTION
With mongoose 5.x the session destruction will fail. This change will fix the issue.

This should fix #277.