### PR TITLE
Add option writeOperationOptions: options object to pass to every MongoDB write operation call that supports it (e.g. update, remove)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ by doing this, setting `touchAfter: 24 * 3600` you are saying to the session be 
                 scenarios where you need to support different types of serializations
                 (e.g., objects and JSON strings) or need to modify the session before using
                 it in your app.
+  - `writeOperationOptions` Options object to pass to every MongoDB write operation call that
+                supports it (e.g. `update`, `remove`). Useful for adjusting the write concern.
+                Only exception: If `autoRemove` is set to `'interval'`, the write concern
+                from the `writeOperationOptions` object will get overwritten.
   - `transformId` (optional) Transform original sessionId in whatever you want to use as storage key.
 
 ## Tests

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ module.exports = function (connect) {
       this.collectionName = options.collection || 'sessions'
       this.autoRemove = options.autoRemove || 'native'
       this.autoRemoveInterval = options.autoRemoveInterval || 10 // minutes
+      this.writeOperationOptions = options.writeOperationOptions || {}
       this.transformFunctions = computeTransformFunctions(options)
 
       this.options = options
@@ -133,9 +134,9 @@ module.exports = function (connect) {
       }
       switch (this.autoRemove) {
         case 'native':
-          return this.collection.createIndex({expires: 1}, {expireAfterSeconds: 0})
+          return this.collection.createIndex({expires: 1}, Object.assign({expireAfterSeconds: 0}, this.writeOperationOptions))
         case 'interval':
-          this.timer = setInterval(() => this.collection.deleteMany(removeQuery(), {w: 0}), this.autoRemoveInterval * 1000 * 60)
+          this.timer = setInterval(() => this.collection.deleteMany(removeQuery(), Object.assign({}, this.writeOperationOptions, {w: 0, j: false})), this.autoRemoveInterval * 1000 * 60)
           this.timer.unref()
           return Promise.resolve()
         default:
@@ -240,7 +241,7 @@ module.exports = function (connect) {
       }
 
       return withCallback(this.collectionReady()
-        .then(collection => collection.updateOne({_id: this.computeStorageId(sid)}, {$set: s}, {upsert: true}))
+        .then(collection => collection.updateOne({_id: this.computeStorageId(sid)}, {$set: s}, Object.assign({upsert: true}, this.writeOperationOptions)))
         .then(rawResponse => {
           if (rawResponse.result) {
             rawResponse = rawResponse.result
@@ -280,7 +281,7 @@ module.exports = function (connect) {
       }
 
       return withCallback(this.collectionReady()
-        .then(collection => collection.updateOne({_id: this.computeStorageId(sid)}, {$set: updateFields}))
+        .then(collection => collection.updateOne({_id: this.computeStorageId(sid)}, {$set: updateFields}, this.writeOperationOptions))
         .then(result => {
           if (result.nModified === 0) {
             throw new Error('Unable to find the session to touch')
@@ -293,7 +294,7 @@ module.exports = function (connect) {
 
     destroy(sid, callback) {
       return withCallback(this.collectionReady()
-        .then(collection => collection.deleteOne({_id: this.computeStorageId(sid)}))
+        .then(collection => collection.deleteOne({_id: this.computeStorageId(sid)}, this.writeOperationOptions))
         .then(() => this.emit('destroy', sid))
         , callback)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -307,7 +307,7 @@ module.exports = function (connect) {
 
     clear(callback) {
       return withCallback(this.collectionReady()
-        .then(collection => collection.drop())
+        .then(collection => collection.drop(this.writeOperationOptions))
         , callback)
     }
 


### PR DESCRIPTION
Useful for adjusting the write concern.