### PR TITLE
Bump Version due to backward-compatible API change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mongo",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "MongoDB session store for Express and Connect",
   "keywords": [
     "connect",


### PR DESCRIPTION
@jdesboeufs  and @mingchuno for comments:

I was following the README.md option only to realize `MongoStore({client: ...})` is recently made available in commit 27cf04af561c6f583662ffb4f2547dc9f65f506c by author @mingchuno, which is a new API interface available. I suggest bump up version so NPM can get the new version.

Per https://github.com/jdesboeufs/connect-mongo/commit/27cf04af561c6f583662ffb4f2547dc9f65f506c#diff-1fdf421c05c1140f6d71444ea2b27638R103