### PR TITLE
Wait for client open, before calling db.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,11 @@ module.exports = function (connect) {
           options.mongooseConnection.once('open', () => this.handleNewConnectionAsync(options.mongooseConnection))
         }
       } else if (options.client) {
-        this.handleNewConnectionAsync(options.client)
+        if (options.client.isConnected()) {
+          this.handleNewConnectionAsync(options.client)
+        } else {
+          options.client.once('open', () => this.handleNewConnectionAsync(options.client))
+        }
       } else if (options.clientPromise) {
         options.clientPromise
           .then(client => this.handleNewConnectionAsync(client))


### PR DESCRIPTION
The patch checks if the client is connected, and if not, registers an event listener for the open event.  Once the event fires, the new connection proceeds as normal.

If a non-connected client is passed in currently, it will fail with the following error:

```
MongoError: MongoClient must be connected before calling MongoClient.prototype.db
```

This works with the native MongoDB driver, and follows a similar pattern to the existing handling of Mongoose connections.