### PR TITLE
fix: add missing `secret` option to TS definition

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -81,6 +81,11 @@ declare namespace connectMongo {
          * don't save session if unmodified
          */
         touchAfter?: number;
+
+        /**
+         * Enables transparent crypto in accordance with OWASP session management recommendations.
+         */
+        secret?: string
     }
 
     export interface MongoUrlOptions extends DefaultOptions {


### PR DESCRIPTION
This option is already supported in the code and documented in:
https://github.com/jdesboeufs/connect-mongo#crypto-options