### PR TITLE
feat: add dbName option

### DIFF
--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const expressSession = require('express-session')
+const MongoClient = require('mongodb')
+const MongoStore = require('..')(expressSession)
+
+const connectionString =
+  process.env.MONGODB_URL || 'mongodb://localhost:27017/connect-mongo-test'
+
+const mongoOptions = { useNewUrlParser: true }
+
+describe('Validate options', () => {
+  let store
+  afterEach(() => {
+    return store.close()
+  })
+
+  describe('dbName option', () => {
+    const dbName = 'dbName-test'
+    test('dbName should be set to databaseName w/ url', done => {
+      store = new MongoStore({
+        url: connectionString,
+        dbName,
+      })
+      store.once('connected', () => {
+        expect(store.db.databaseName).toEqual(dbName)
+        done()
+      })
+    })
+
+    test('dbName should be set to databaseName w/ client', done => {
+      MongoClient.connect(connectionString, mongoOptions, (err, client) => {
+        expect(err).toBeFalsy()
+        store = new MongoStore({
+          client,
+          dbName,
+        })
+        store.once('connected', () => {
+          expect(store.db.databaseName).toEqual(dbName)
+          done()
+        })
+      })
+    })
+
+    test('dbName should be set to databaseName w/ clientPromise', done => {
+      const clientPromise = MongoClient.connect(connectionString, mongoOptions)
+      store = new MongoStore({
+        clientPromise,
+        dbName,
+      })
+      store.once('connected', () => {
+        expect(store.db.databaseName).toEqual(dbName)
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR is a result of discussion #335 in which a couple of methods for specifying which database to use were suggested:

1. Adding database *name* option which can be passed to `client.db()`
2. Adding database *instance* option which can be used without needing to invoke `client.db()`

This PR implemented 1, because the codebase seemed to be built in light of `client`, e.g. `MongoStore.close()` won't be invoked when database instance is used, and I wanted to add as little code as possible.

And this PR will also update `README.md` to add example usage for `dbName` option and to incorporate all available options into Options section.