### PR TITLE
Add missing "dbName" parameter

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -99,6 +99,7 @@ declare namespace connectMongo {
 
     export interface NativeMongoOptions extends DefaultOptions {
         client: mongodb.MongoClient;
+        dbName: string;
     }
 
     export interface NativeMongoPromiseOptions extends DefaultOptions {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -104,6 +104,7 @@ declare namespace connectMongo {
 
     export interface NativeMongoPromiseOptions extends DefaultOptions {
         clientPromise: Promise<mongodb.MongoClient>;
+        dbName: string;
     }
 
     export interface MongoStoreFactory {


### PR DESCRIPTION
[According to the code](https://github.com/jdesboeufs/connect-mongo/blob/master/src/index.js#L114) one needs to pass the `dbName` parameter if you provide a client or a client promise. However, they do not exist in the types definitions so my IDE is giving me pain for including something that it thinks is invalid.

I'm not very informed of this code base. Do any changes that you feel nessecary and pardon me if this has been covered before.