### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ module.exports = function(connect) {
         if (options.mongooseConnection.readyState === 1) {
           this.handleNewConnectionAsync(options.mongooseConnection)
         } else {
-          options.mongooseConnection.once('open', () =>
+          options.mongooseConnection.once('all', () =>
             this.handleNewConnectionAsync(options.mongooseConnection)
           )
         }


### PR DESCRIPTION
Got an error with connection to replicaset, caught in handleNewConnectionAsync function. handleNewConnectionAsync should start not when the connection open but when driver connected to all replicaset and resolve config, otherwise it would try to read collection from protected member. I'm not sure about behavior for single node scenario.

@event **all**: Emitted in a replica-set scenario, when all nodes specified in the connection string are connected.

connect options
`{  replicaSet: 'rs1',
  connectWithNoPrimary: true,
  readPreference: 'nearest',
  w: 1,
  wtimeout: 10000,
  j: 1,
  keepAlive: true,
  family: 4,
  poolSize: 10,
  socketTimeoutMS: 5 * 60000,
  autoIndex: false}`