### PR TITLE
Update MIGRATION_V4.md

### DIFF
--- a/MIGRATION_V4.md
+++ b/MIGRATION_V4.md
@@ -42,6 +42,7 @@ app.use(session({
 For the options, you should make the following changes:
 
 * Change `url` to `mongoUrl`
+* Change `collection` to `collectionName` if you are using it
 * Keep `clientPromise` if you are using it
 * `mongooseConnection` has been removed. Please update your application code to use either `mongoUrl`, `client` or `clientPromise`
 * To reuse an existing mongoose connection retreive the mongoDb driver from you mongoose connection using `Connection.prototype.getClient()` and pass it to the store in the `client`-option.


### PR DESCRIPTION
I spent several hours understanding why mongo doesn't find a session record.
Only via the debugger, I figure out that it uses the default collection with the name `sessions` instead of my custom name.
