### PR TITLE
fix: require engines newer than node 12.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `engines` to require Node 12.9 or newer, matching the upgrade to `mongodb` that occurred in `v4.5.0`
+
 ## [4.6.0] - 2021-09-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12.9.0"
   },
   "peerDependencies": {
     "mongodb": "^4.1.0"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Bug fix

- **What is the current behavior?** Allows installation on Node < 12

- **What is the new behavior (if this is a feature change)?** Requires Node >= 12.9 to install.

- **Other information**: This matches the engine required by the mongodb package;
see https://github.com/mongodb/node-mongodb-native/blob/4.1/package.json#L88

- **Checklist:**

- [ ] Added test cases
- [x] Updated changelog
