### PR TITLE
fix: declare `express-session` as a peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change `engines` to require Node 12.9 or newer, matching the upgrade to `mongodb` that occurred in `v4.5.0`
+- Declare `express-session` as a peer dependency.
 
 ## [4.6.0] - 2021-09-17
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "node": ">=12.9.0"
   },
   "peerDependencies": {
+    "express-session": "^1.17.1",
     "mongodb": "^4.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix, adds `express-session` as a peer dependency.

Fixes https://github.com/yarnpkg/berry/issues/4368

- **What is the current behavior?** (You can also link to an open issue here)

`connect-mongo` crashes when attempting to require `express-session` if the hoisting didn't make it accessible.

- **Checklist:**

  - [ ] Added test cases
  - [x] Updated changelog
