### PR TITLE
Upgrade mongodb to 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change `engines` to require Node 12.9 or newer, matching the upgrade to `mongodb` that occurred in `v4.5.0`
 
+## [5.0.0] - 2023-03-13
+
+### **BREAKING CHANGES**
+
+- Upgraded peer dependency `mongodb` to 5.0.0
+
 ## [4.6.0] - 2021-09-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mongo",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "description": "MongoDB session store for Express and Connect",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -57,7 +57,7 @@
     "node": ">=12.9.0"
   },
   "peerDependencies": {
-    "mongodb": "^4.1.0"
+    "mongodb": "^5.1.0"
   },
   "dependencies": {
     "debug": "^4.3.1",
@@ -94,7 +94,7 @@
     "gh-pages": "^3.1.0",
     "husky": "4",
     "lint-staged": "^10.5.4",
-    "mongodb": "^4.1.0",
+    "mongodb": "^5.1.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "open-cli": "^6.0.1",

--- a/src/lib/MongoStore.spec.ts
+++ b/src/lib/MongoStore.spec.ts
@@ -172,8 +172,12 @@ test.serial('test set default TTL', async (t) => {
   const collection = await store.collectionP
   const session = await collection.findOne({ _id: sid })
   const timeAfterSet = new Date().valueOf()
-  t.truthy(timeBeforeSet + defaultTTL * 1000 <= session?.expires.valueOf())
-  t.truthy(session?.expires.valueOf() <= timeAfterSet + defaultTTL * 1000)
+  const expires = session?.expires?.valueOf()
+  t.truthy(expires)
+  if (expires) {
+    t.truthy(timeBeforeSet + defaultTTL * 1000 <= expires)
+    t.truthy(expires <= timeAfterSet + defaultTTL * 1000)
+  }
 })
 
 test.serial('test default TTL', async (t) => {
@@ -187,8 +191,12 @@ test.serial('test default TTL', async (t) => {
   const collection = await store.collectionP
   const session = await collection.findOne({ _id: sid })
   const timeAfterSet = new Date().valueOf()
-  t.truthy(timeBeforeSet + defaultExpirationTime <= session?.expires.valueOf())
-  t.truthy(session?.expires.valueOf() <= timeAfterSet + defaultExpirationTime)
+  const expires = session?.expires?.valueOf()
+  t.truthy(expires)
+  if (expires) {
+    t.truthy(timeBeforeSet + defaultExpirationTime <= expires)
+    t.truthy(expires <= timeAfterSet + defaultExpirationTime)
+  }
 })
 
 test.serial('test custom serializer', async (t) => {
@@ -244,7 +252,11 @@ test.serial('touch ops', async (t) => {
   const session2 = await collection.findOne({ _id: sid })
   t.not(session2, undefined)
   // Check if both expiry date are different
-  t.truthy(session2?.expires.getTime() > session?.expires.getTime())
+  t.truthy(session2?.expires?.getTime())
+  t.truthy(session?.expires?.getTime())
+  if (session?.expires?.getTime() && session2?.expires?.getTime()) {
+    t.truthy(session2?.expires.getTime() > session?.expires.getTime())
+  }
 })
 
 test.serial('touch ops with touchAfter', async (t) => {
@@ -255,12 +267,12 @@ test.serial('touch ops with touchAfter', async (t) => {
   await storePromise.set(sid, orgSession)
   const collection = await store.collectionP
   const session = await collection.findOne({ _id: sid })
-  const lastModifiedBeforeTouch = session?.lastModified.getTime()
+  const lastModifiedBeforeTouch = session?.lastModified?.getTime()
   t.not(session, undefined)
-  await storePromise.touch(sid, session as SessionData)
+  await storePromise.touch(sid, (session as unknown) as SessionData)
   const session2 = await collection.findOne({ _id: sid })
   t.not(session2, undefined)
-  const lastModifiedAfterTouch = session2?.lastModified.getTime()
+  const lastModifiedAfterTouch = session2?.lastModified?.getTime()
   // Check if both expiry date are different
   t.is(lastModifiedBeforeTouch, lastModifiedAfterTouch)
 })
@@ -273,15 +285,19 @@ test.serial('touch ops with touchAfter with touch', async (t) => {
   await storePromise.set(sid, orgSession)
   const collection = await store.collectionP
   const session = await collection.findOne({ _id: sid })
-  const lastModifiedBeforeTouch = session?.lastModified.getTime()
+  const lastModifiedBeforeTouch = session?.lastModified?.getTime()
   await new Promise((resolve) => setTimeout(resolve, 1200))
   t.not(session, undefined)
-  await storePromise.touch(sid, session as SessionData)
+  await storePromise.touch(sid, (session as unknown) as SessionData)
   const session2 = await collection.findOne({ _id: sid })
   t.not(session2, undefined)
-  const lastModifiedAfterTouch = session2?.lastModified.getTime()
+  const lastModifiedAfterTouch = session2?.lastModified?.getTime()
   // Check if both expiry date are different
-  t.truthy(lastModifiedAfterTouch > lastModifiedBeforeTouch)
+  t.truthy(lastModifiedAfterTouch)
+  t.truthy(lastModifiedBeforeTouch)
+  if (lastModifiedAfterTouch && lastModifiedBeforeTouch) {
+    t.truthy(lastModifiedAfterTouch > lastModifiedBeforeTouch)
+  }
 })
 
 test.serial('basic operation flow with crypto', async (t) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,19 +1293,17 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-bson@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-4.5.2.tgz#567b4ee94372d5284a4d6c47fb6e1cc711ae76ba"
-  integrity sha512-8CEMJpwc7qlQtrn2rney38jQSEeMar847lz0LyitwRmVknAW8iHXrzW4fTjHfyWm0E3sukyD/zppdH+QU1QefA==
-  dependencies:
-    buffer "^5.6.0"
+bson@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-5.0.1.tgz#4cd3eeeabf6652ef0d6ab600f9a18212d39baac3"
+  integrity sha512-y09gBGusgHtinMon/GVbv1J6FrXhnr/+6hqLlSmEFzkz6PodqF6TxjyvfvY3AfO+oG1mgUtbC86xSbOlwvM62Q==
 
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-buffer@^5.5.0, buffer@^5.6.0:
+buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -2271,11 +2269,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-denque@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-2.0.1.tgz#bcef4c1b80dc32efe97515744f21a4229ab8934a"
-  integrity sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -3724,6 +3717,11 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
+ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
+  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -4756,22 +4754,22 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-mongodb-connection-string-url@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.0.0.tgz#72cea65084ffa45655670070efb57bb0a5da46bc"
-  integrity sha512-M0I1vyLoq5+HQTuPSJWbt+hIXsMCfE8sS1fS5mvP9R2DOMoi2ZD32yWqgBIITyu0dFu4qtS50erxKjvUeBiyog==
+mongodb-connection-string-url@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz#57901bf352372abdde812c81be47b75c6b2ec5cf"
+  integrity sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==
   dependencies:
     "@types/whatwg-url" "^8.2.1"
-    whatwg-url "^9.1.0"
+    whatwg-url "^11.0.0"
 
-mongodb@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.1.2.tgz#36ab494db3a9a827df41ccb0d9b36a94bfeae8d7"
-  integrity sha512-pHCKDoOy1h6mVurziJmXmTMPatYWOx8pbnyFgSgshja9Y36Q+caHUzTDY6rrIy9HCSrjnbXmx3pCtvNZHmR8xg==
+mongodb@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-5.1.0.tgz#e551f9e496777bde9173e51d16c163ab2c805b9d"
+  integrity sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==
   dependencies:
-    bson "^4.5.2"
-    denque "^2.0.1"
-    mongodb-connection-string-url "^2.0.0"
+    bson "^5.0.1"
+    mongodb-connection-string-url "^2.6.0"
+    socks "^2.7.1"
   optionalDependencies:
     saslprep "^1.0.3"
 
@@ -6084,6 +6082,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+smart-buffer@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -6113,6 +6116,14 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+socks@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
+  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
+  dependencies:
+    ip "^2.0.0"
+    smart-buffer "^4.2.0"
 
 sort-keys@^1.0.0:
   version "1.1.2"
@@ -6676,10 +6687,10 @@ token-types@^2.0.0:
     "@tokenizer/token" "^0.1.0"
     ieee754 "^1.1.13"
 
-tr46@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240"
-  integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
+tr46@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
 
@@ -6979,23 +6990,23 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-webidl-conversions@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
-  integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
 well-known-symbols@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/well-known-symbols/-/well-known-symbols-2.0.0.tgz#e9c7c07dbd132b7b84212c8174391ec1f9871ba5"
   integrity sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==
 
-whatwg-url@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-9.1.0.tgz#1b112cf237d72cd64fa7882b9c3f6234a1c3050d"
-  integrity sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==
+whatwg-url@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
   dependencies:
-    tr46 "^2.1.0"
-    webidl-conversions "^6.1.0"
+    tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* MongoDB 5.0 has been released for a while, this PR introduces a breaking change to upgrade the peer dependency `mongodb` to 5.0.0

- **What is the current behavior?** (You can also link to an open issue here)

https://github.com/jdesboeufs/connect-mongo/issues/465

- **What is the new behavior (if this is a feature change)?**

I considered the changes in this PR as breaking changes since the `MongoClient` typing in mongodb@5 is not compatible with the one in mongodb@4, so the upgrade will break the interface.

- **Other information**:

- **Checklist:**

- [x] Added test cases
- [x] Updated changelog
