### PR TITLE
chore: extend mongodb compatibility to 6.x

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -34,7 +34,7 @@ jobs:
       - run: yarn install
       - run: yarn test
       - run: yarn add mongodb@6 && yarn test
-        if: ${{ matrix.node-version !== '14.x' }} 
+        if: ${{ matrix.node-version != '14.x' }} 
       - run: yarn cov:send
       - run: yarn cov:check
       - run: yarn build

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -34,7 +34,7 @@ jobs:
       - run: yarn install
       - run: yarn test
       - run: yarn add mongodb@6 && yarn test
-        if: ${{ matrix.node-version }} !== '14.x'
+        if: ${{ matrix.node-version !== '14.x' }} 
       - run: yarn cov:send
       - run: yarn cov:check
       - run: yarn build

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -33,6 +33,8 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: yarn install
       - run: yarn test
+      - run: yarn add mongodb@6 && yarn test
+        if: ${{ matrix.node-version }} !== '14.x'
       - run: yarn cov:send
       - run: yarn cov:check
       - run: yarn build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.0.0] - 2023-08-28
-
-### **BREAKING CHANGES**
-
-- Upgraded peer dependency `mongodb` to 6.0.0
-- Change `engines` to require Node 16.20.1 or newer, matching the upgrade to `mongodb` that occurred in `v6.0.0`
+- Upgrade peer dependency `mongodb` to v5 or v6
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0] - 2023-08-28
+
+### **BREAKING CHANGES**
+
+- Upgraded peer dependency `mongodb` to 6.0.0
+- Change `engines` to require Node 16.20.1 or newer, matching the upgrade to `mongodb` that occurred in `v6.0.0`
+
 ### Changed
 
 - Upgrade dependency

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ yarn add connect-mongo
 ## Compatibility
 
 * Support Express up to `5.0`
-* Support [native MongoDB driver](http://mongodb.github.io/node-mongodb-native/) `>= 6.0`
+* Support [native MongoDB driver](http://mongodb.github.io/node-mongodb-native/) `5` and `6`
 * Support Node.js 14, 16 and 18
 * Support [MongoDB](https://www.mongodb.com/) `3.6+`
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ yarn add connect-mongo
 ## Compatibility
 
 * Support Express up to `5.0`
-* Support [native MongoDB driver](http://mongodb.github.io/node-mongodb-native/) `>= 5.0`
+* Support [native MongoDB driver](http://mongodb.github.io/node-mongodb-native/) `>= 6.0`
 * Support Node.js 14, 16 and 18
 * Support [MongoDB](https://www.mongodb.com/) `3.6+`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mongo",
-  "version": "6.0.0",
+  "version": "5.0.0",
   "description": "MongoDB session store for Express and Connect",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -54,11 +54,11 @@
     "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish"
   },
   "engines": {
-    "node": ">=16.20.0"
+    "node": ">=12.9.0"
   },
   "peerDependencies": {
     "express-session": "^1.17.1",
-    "mongodb": "^6.0.0"
+    "mongodb": ">= 5.0.0 < 7"
   },
   "dependencies": {
     "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mongo",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "MongoDB session store for Express and Connect",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -54,11 +54,11 @@
     "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish"
   },
   "engines": {
-    "node": ">=12.9.0"
+    "node": ">=16.20.0"
   },
   "peerDependencies": {
     "express-session": "^1.17.1",
-    "mongodb": "^5.1.0"
+    "mongodb": "^6.0.0"
   },
   "dependencies": {
     "debug": "^4.3.1",
@@ -95,7 +95,7 @@
     "gh-pages": "^3.1.0",
     "husky": "4",
     "lint-staged": "^10.5.4",
-    "mongodb": "^5.1.0",
+    "mongodb": "^6.0.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "open-cli": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "express-session": "^1.17.1",
-    "mongodb": ">= 5.0.0 < 7"
+    "mongodb": ">= 5.1.0 < 7"
   },
   "dependencies": {
     "debug": "^4.3.1",
@@ -95,7 +95,7 @@
     "gh-pages": "^3.1.0",
     "husky": "4",
     "lint-staged": "^10.5.4",
-    "mongodb": "^6.0.0",
+    "mongodb": "^5.1.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "open-cli": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,6 +567,13 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
+"@mongodb-js/saslprep@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz#022fa36620a7287d17acd05c4aae1e5f390d250d"
+  integrity sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1335,10 +1342,10 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-bson@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-5.0.1.tgz#4cd3eeeabf6652ef0d6ab600f9a18212d39baac3"
-  integrity sha512-y09gBGusgHtinMon/GVbv1J6FrXhnr/+6hqLlSmEFzkz6PodqF6TxjyvfvY3AfO+oG1mgUtbC86xSbOlwvM62Q==
+bson@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-6.0.0.tgz#685f631a2ce255e2ed3987a7355210e4beace17e"
+  integrity sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg==
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -3870,11 +3877,6 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-ip@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
-  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
-
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -4904,16 +4906,14 @@ mongodb-connection-string-url@^2.6.0:
     "@types/whatwg-url" "^8.2.1"
     whatwg-url "^11.0.0"
 
-mongodb@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-5.1.0.tgz#e551f9e496777bde9173e51d16c163ab2c805b9d"
-  integrity sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==
+mongodb@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-6.0.0.tgz#a01f989d0c1ceb7b08068551c545e6131557a1e8"
+  integrity sha512-wUIYesF4DTyDccm0noE5TwGi9ISdXUAi9T2cQ4xPc+EUBZG44bfMVt2ecOG5Ypca7eCz3oRpJm6YI6c7jAnuNw==
   dependencies:
-    bson "^5.0.1"
+    "@mongodb-js/saslprep" "^1.1.0"
+    bson "^6.0.0"
     mongodb-connection-string-url "^2.6.0"
-    socks "^2.7.1"
-  optionalDependencies:
-    saslprep "^1.0.3"
 
 ms@2.0.0:
   version "2.0.0"
@@ -5972,13 +5972,6 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-saslprep@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.3.tgz#4c02f946b56cf54297e347ba1093e7acac4cf226"
-  integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
-  dependencies:
-    sparse-bitfield "^3.0.3"
-
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -6149,11 +6142,6 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-smart-buffer@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
-  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
-
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -6183,14 +6171,6 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
-
-socks@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
-  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
-  dependencies:
-    ip "^2.0.0"
-    smart-buffer "^4.2.0"
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Updates the `mongodb` dependency from v5.0.0 to v6.0.0.

I didn't see anything in the [release notes](https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_6.0.0.md) to warrant changes to the code, so this PR just updates the MongoDB and Node versions, following the PR for v5.

- **Checklist:**

- [n/a] Added test cases
- [x] Updated changelog
