### PR TITLE
fix: added better typescript support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added typescript generics to some methods
+
 ## [5.1.0] - 2023-10-14
 
 ### Changed

--- a/src/lib/MongoStore.spec.ts
+++ b/src/lib/MongoStore.spec.ts
@@ -98,7 +98,7 @@ test.serial.cb('set and listen to event', (t) => {
     store.get(sid, (err, session) => {
       t.is(err, null)
       t.is(typeof session, 'object')
-      t.deepEqual(session, orgSession)
+      t.deepEqual(session, orgSession as unknown as SessionData)
       t.end()
     })
   })
@@ -120,7 +120,7 @@ test.serial.cb('set and listen to update event', (t) => {
   const orgSession = makeData()
   const sid = 'test-update-event'
   store.set(sid, orgSession)
-  store.set(sid, { ...orgSession, foo: 'new-bar' } as SessionData)
+  store.set(sid, { ...orgSession, foo: 'new-bar' })
   store.on('update', (sessionId) => {
     t.is(sessionId, sid)
     t.end()
@@ -212,10 +212,8 @@ test.serial('test custom serializer', async (t) => {
   const session = await storePromise.get(sid)
   t.is(typeof session, 'string')
   t.not(session, undefined)
-  // @ts-ignore
   orgSession.ice = 'test-ice-serializer'
-  // @ts-ignore
-  t.is(session, JSON.stringify(orgSession))
+  t.is(`${session}`, JSON.stringify(orgSession))
 })
 
 test.serial('test custom deserializer', async (t) => {
@@ -230,9 +228,7 @@ test.serial('test custom deserializer', async (t) => {
   await storePromise.set(sid, orgSession)
   const session = await storePromise.get(sid)
   t.is(typeof session, 'object')
-  // @ts-ignore
-  orgSession.cookie = orgSession.cookie.toJSON()
-  // @ts-ignore
+  if (orgSession.cookie) orgSession.cookie = orgSession.cookie.toJSON()
   orgSession.ice = 'test-ice-deserializer'
   t.not(session, undefined)
   t.deepEqual(session, orgSession)
@@ -242,7 +238,6 @@ test.serial('touch ops', async (t) => {
   ;({ store, storePromise } = createStoreHelper())
   const orgSession = makeDataNoCookie()
   const sid = 'test-touch'
-  // @ts-ignore
   await storePromise.set(sid, orgSession)
   const collection = await store.collectionP
   const session = await collection.findOne({ _id: sid })
@@ -263,7 +258,6 @@ test.serial('touch ops with touchAfter', async (t) => {
   ;({ store, storePromise } = createStoreHelper({ touchAfter: 1 }))
   const orgSession = makeDataNoCookie()
   const sid = 'test-touch-with-touchAfter'
-  // @ts-ignore
   await storePromise.set(sid, orgSession)
   const collection = await store.collectionP
   const session = await collection.findOne({ _id: sid })
@@ -281,7 +275,6 @@ test.serial('touch ops with touchAfter with touch', async (t) => {
   ;({ store, storePromise } = createStoreHelper({ touchAfter: 1 }))
   const orgSession = makeDataNoCookie()
   const sid = 'test-touch-with-touchAfter-should-touch'
-  // @ts-ignore
   await storePromise.set(sid, orgSession)
   const collection = await store.collectionP
   const session = await collection.findOne({ _id: sid })

--- a/src/test/integration.spec.ts
+++ b/src/test/integration.spec.ts
@@ -2,14 +2,8 @@ import test from 'ava'
 import request from 'supertest'
 import express from 'express'
 import session, { SessionOptions } from 'express-session'
-import MongoStore from '../'
+import MongoStore from '..'
 import { ConnectMongoOptions } from '../lib/MongoStore'
-
-declare module 'express-session' {
-  interface SessionData {
-    [key: string]: any
-  }
-}
 
 function createSupertetAgent(
   sessionOpts: SessionOptions,

--- a/src/test/testHelper.ts
+++ b/src/test/testHelper.ts
@@ -16,6 +16,19 @@ export const makeCookie = () => {
   return cookie
 }
 
+export type makeDataType = {
+  foo: string
+  baz: {
+    cow?: string
+    chicken?: string
+    fish?: string
+    fox?: string
+  }
+  num: number
+  ice?: string
+  cookie?: ExpressSession.Cookie
+}
+
 // Create session data
 export const makeData = () => {
   return {
@@ -26,7 +39,7 @@ export const makeData = () => {
     },
     num: 1,
     cookie: makeCookie(),
-  }
+  } as makeDataType
 }
 
 export const makeDataNoCookie = () => {
@@ -38,7 +51,7 @@ export const makeDataNoCookie = () => {
       fox: 'nobody knows!',
     },
     num: 2,
-  }
+  } as makeDataType
 }
 
 export const createStoreHelper = (opt: Partial<ConnectMongoOptions> = {}) => {
@@ -53,10 +66,10 @@ export const createStoreHelper = (opt: Partial<ConnectMongoOptions> = {}) => {
   const storePromise = {
     length: util.promisify(store.length).bind(store),
     clear: util.promisify(store.clear).bind(store),
-    get: util.promisify(store.get).bind(store),
-    set: util.promisify(store.set).bind(store),
-    all: util.promisify(store.all).bind(store),
-    touch: util.promisify(store.touch).bind(store),
+    get: util.promisify(store.get<makeDataType>).bind(store),
+    set: util.promisify(store.set<makeDataType>).bind(store),
+    all: util.promisify(store.all<makeDataType>).bind(store),
+    touch: util.promisify(store.touch<makeDataType>).bind(store),
     destroy: util.promisify(store.destroy).bind(store),
     close: store.close.bind(store),
   }

--- a/src/types/express/index.d.ts
+++ b/src/types/express/index.d.ts
@@ -1,0 +1,12 @@
+export {}
+
+declare module 'express-session' {
+  interface SessionData {
+    iat: number
+    views: number | unknown
+    session: string
+  }
+  interface Cookie {
+    toJSON: () => Cookie
+  }
+}


### PR DESCRIPTION
Added generics to methods and centralized express-session declaration

- Bug fix: Added generics to some methods to handle custom session data, cleaned up some any types, and centralized express-session declaration to avoid any typing
- Currently using type any to bypass a lot of type-checking
- Increase typescript support and allow users to provide custom session types. They can also keep it at any or keep code as SessionData

- [x] Modified test cases with typing
- [x] Updated changelog
